### PR TITLE
Remove bye from match slips

### DIFF
--- a/taw/__init__.py
+++ b/taw/__init__.py
@@ -84,6 +84,8 @@ def home():
 
         if request.form["action"] == "match_slips":
             pairings = form.parsed_pairings
+            # Filter out the bye before sorting:
+            pairings = [pairing for pairing in pairings if not pairing.player_2.is_bye]
             # We want to print five match slips per page, and we want
             # them to in the "correct" order when we use the paper cutter
             pairings = sort_pairings_for_paper_cutter(

--- a/taw/testing/outputs/match_slips_pairings_with_bye.html
+++ b/taw/testing/outputs/match_slips_pairings_with_bye.html
@@ -962,7 +962,7 @@
 
   <div class="container-fluid match-slip-container" style="position:relative">
     <div class="row">
-        <div class="col-2 d-flex justify-content-start"><b>Table #12</b></div>
+        <div class="col-2 d-flex justify-content-start"><b>Table #</b></div>
         <div class="col-2 d-flex justify-content-center">
             
         </div>
@@ -981,7 +981,7 @@
 
     <div class="row my-2 match-slip__p1-infos">
         <div class="col-5 match-slip__name">
-            Georges Pompidou (0 pts)
+             
         </div>
         <div class="col-2 signature">
           <div class="match-slip__signature-label">PLAYER 1</div>
@@ -1005,7 +1005,7 @@
 
     <div class="row my-2 match-slip__p2-infos">
         <div class="col-5 match-slip__name">
-            * * * BYE * * * (0 pts)
+             
         </div>
         <div class="col-2 signature">
           <div class="match-slip__signature-label">PLAYER 2</div>


### PR DESCRIPTION
The player with the bye is removed from the pairings before they are sorted, during match slips creation.

Should close #46.